### PR TITLE
Display MRR and Aggregate Stripe Data on CMS Dashboard

### DIFF
--- a/app/javascript/stylesheets/rails_admin.scss
+++ b/app/javascript/stylesheets/rails_admin.scss
@@ -34,3 +34,6 @@ body.rails_admin .sidebar.btn-toggle-nav .btn-toggle-nav > li > a.active,
 body.rails_admin .sidebar.btn-toggle-nav .btn-toggle-nav > li > a:hover {
   background-color: #2e8b57 !important;
 }
+.nav-tabs .nav-item.dashboard_root_link {
+  display: none !important;
+}

--- a/app/views/rails_admin/main/dashboard.html.erb
+++ b/app/views/rails_admin/main/dashboard.html.erb
@@ -1,0 +1,50 @@
+<div class="row">
+  <!-- Monthly Recurring Revenue -->
+  <div class="col-md-6">
+    <div class="panel panel-info">
+      <div class="panel-heading"><strong>Monthly Recurring Revenue (MRR)</strong></div>
+      <div class="panel-body">
+        <% active_users = User.where(subscription_status: 'active') %>
+        <% mrr = active_users.sum { |u| u.payment_amount.to_f / 100 } %>
+
+        <h2><%= number_to_currency(mrr, precision: 2) %></h2>
+      </div>
+    </div>
+  </div>
+
+  <!-- Total Subscriber Count  -->
+  <div class="col-md-6">
+    <div class="panel panel-success">
+      <div class="panel-heading"><strong>Active Subscribers</strong></div>
+      <div class="panel-body">
+        <h2><%= active_users.count %></h2>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Plans And Subscribers -->
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading"><strong>Subscribers by Plan</strong></div>
+      <div class="panel-body">
+        <ul>
+          <% grouped = active_users.group_by(&:plan) %>
+          <% sorted = grouped.sort_by { |plan, users| users.first.payment_amount } %>
+
+          <% sorted.each do |plan, users| %>
+            <% plan_name = plan.present? ? plan.tr('_', ' ').titleize : 'Unspecified' %>
+            <% price = users.first.payment_amount.to_f / 100 rescue 0 %>
+            <% total = users.sum { |u| u.payment_amount.to_f / 100 } %>
+            <li>
+              <strong><%= plan_name %>:</strong>
+              <%= users.count %> users @ <%= number_to_currency(price) %>/mo —
+              <em>Total: <%= number_to_currency(total) %></em>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,8 +1,8 @@
 RailsAdmin.config do |config|
   config.asset_source = :webpacker
   config.main_app_name = ["Produce Bridge Admin", ""]
-  ### Popular gems integration
 
+  ### Gem Integration
   ## == Devise ==
    config.authenticate_with do
      warden.authenticate! scope: :user
@@ -13,7 +13,7 @@ RailsAdmin.config do |config|
      # Redirect non-admin users to the root path
      redirect_to main_app.root_path unless current_user&.admin?
   end
-
+  
   ## == CancanCan ==
   # config.authorize_with :cancancan
 


### PR DESCRIPTION
Summary of Changes:

- Overwrote the default CMS dashboard
- Integrated monthly recurring revenue calculation
- Added section to display total subscribers
- Integrated plan breakdown section to display subscribers per plan and plan costs
- Removed redundant dashboard tab below breadcrumbs

All stripe elements are fetched dynamically from the user column and will reflect any changes made to plan names and pricing.